### PR TITLE
[#8] Replace Circle with Spaceship

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,3 +1,4 @@
+# This workflow runs a linter's on various file types
 name: Validate
 on: push
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,3 @@
-# This workflow runs a linter's on various file types
 name: Validate
 on: push
 

--- a/images/example.svg
+++ b/images/example.svg
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" id="svgCanvas" version="1.1" height="128" width="128" viewBox="0 0 128 128" xml:space="preserve">
-    <circle id="myCircle" cx="50" cy="50" r="40" fill="magenta" stroke="gray" stroke-width="2"/>
-</svg>

--- a/images/spaceship.svg
+++ b/images/spaceship.svg
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg xmlns="http://www.w3.org/2000/svg" id="svgCanvas" version="1.1" height="200" width="200" viewBox="0 0 200 200" xml:space="preserve">
-    <ellipse cx="100" cy="100" rx="50" ry="80" fill="gray" stroke="black" stroke-width="2"/>
-    <circle cx="100" cy="70" r="15" fill="lightblue" stroke="black" stroke-width="2"/>
-    <polygon points="50,120 10,150 50,160" fill="gray" stroke="black" stroke-width="2"/>
-    <polygon points="150,120 190,150 150,160" fill="gray" stroke="black" stroke-width="2"/>
-    <rect x="85" y="170" width="10" height="20" fill="red" stroke="black" stroke-width="2"/>
-    <rect x="105" y="170" width="10" height="20" fill="red" stroke="black" stroke-width="2"/>
+    <g id="spaceship">
+        <ellipse cx="100" cy="100" rx="50" ry="80" fill="gray" stroke="black" stroke-width="2"/>
+        <circle id="spaceshipWindow" cx="100" cy="70" r="15" fill="lightblue" stroke="black" stroke-width="2"/>
+        <polygon points="50,120 10,150 50,160" fill="gray" stroke="black" stroke-width="2"/>
+        <polygon points="150,120 190,150 150,160" fill="gray" stroke="black" stroke-width="2"/>
+        <rect x="85" y="170" width="10" height="20" fill="red" stroke="black" stroke-width="2"/>
+        <rect x="105" y="170" width="10" height="20" fill="red" stroke="black" stroke-width="2"/>
+    </g>
 </svg>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <div id="svgContainer">Loading SVG...</div>
 
     <!-- Button to move the circle -->   
-    <button onclick="moveCircle()">Move Right</button>
+    <button onclick="moveObejectRight()">Move Right</button>
     <!-- Button to change SVG color -->
     <button onclick="changeSVGColor()">Change Circle Color</button>
 

--- a/scritps/script.js
+++ b/scritps/script.js
@@ -19,7 +19,7 @@
           // Load the SVG dynamically
           function loadSVG() {
             document.getElementById("svgContainer").innerHTML ="started"
-            fetch("images/example.svg") // Replace with your actual SVG file path
+            fetch("images/spaceship.svg") // Replace with your actual SVG file path
                 .then(response => {
                     if (!response.ok) {
                         throw new Error('Network response was not ok');

--- a/scritps/script.js
+++ b/scritps/script.js
@@ -4,9 +4,9 @@
         //     circle.setAttribute("cx", currentX + 20);
         // }
 
-        function moveCircle() {
+        function moveObejectRight() {
 
-             moveSection('myCircle', 20, 0);
+             moveSection('spaceship', 20, 0);
            }
 
         function moveSection(idStr, xOffset, yOffset) {
@@ -27,7 +27,11 @@
                     return response.text();
                 }) // Get the SVG as text
                 .then(svgText => {
-                    document.getElementById("svgContainer").innerHTML = svgText; // Inject SVG
+                    //remove the SVG header and add a new one
+                    let svgLines = svgText.split('\n');
+                    svgLines.splice(0, 3, '<svg id="svgCanvas" xmlns="http://www.w3.org/2000/svg" version="1.1" height="200" width="200" viewBox="0 0 200 200">');
+                    updatedSVG = svgLines.join('\n');
+                    document.getElementById("svgContainer").innerHTML = updatedSVG; // Inject SVG
                 })
                 .catch(error => {
                     console.error("Error loading SVG:", error);
@@ -37,12 +41,9 @@
 
         // Change the color of a specific element inside the SVG
         function changeSVGColor() {
-            let svgElement = document.querySelector("#svgContainer svg"); // Select the SVG
-            if (svgElement) {
-                let circle = svgElement.querySelector("myCircle"); // Select the circle inside the SVG
-                if (circle) {
-                    circle.setAttribute("fill", "red"); // Change color
-                }
+            var domElemnt = document.getElementById("spaceshipWindow");
+            if (domElemnt) {
+                domElemnt.setAttribute("fill", "red"); 
             }
         }
 

--- a/styles/style.css
+++ b/styles/style.css
@@ -14,7 +14,7 @@ body {
 
 /* Fancy glassmorphism container for the SVG */
 #svgContainer {
-    width: 300px;
+    width: 400px;
     height: 300px;
     background: rgba(255, 255, 255, 0.6);
     backdrop-filter: blur(15px);


### PR DESCRIPTION
Update SVG file reference in script.js

Replace the reference to "images/example.svg" with "images/spaceship. svg" for dynamic SVG loading. This change ensures that the correct SVG is fetched by the script.